### PR TITLE
refacto: jwt verify in async mode

### DIFF
--- a/src/utils/jwt.service.ts
+++ b/src/utils/jwt.service.ts
@@ -26,13 +26,19 @@ class JwtService {
 			return null;
 		}
 
-		try {
-			return jwt.verify(token, process.env.JWT_SECRET!, {
-				...this.options,
-			}) as Payload;
-		} catch (error) {
-			return null;
-		}
+		return new Promise<Payload>((resolve, reject) => {
+			jwt.verify(
+				token,
+				process.env.JWT_SECRET!,
+				{ ...this.options },
+				(err, payload) => {
+					if (err) {
+						return reject(err);
+					}
+					return resolve(payload as Payload);
+				}
+			);
+		});
 	}
 
 	public signRefresh(payload: RefreshPayload) {


### PR DESCRIPTION
We can enforce the JWT verify function to be executed asynchronously if we provide a callback argument.
More info here: [https://www.npmjs.com/package/jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback](https://www.npmjs.com/package/jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
👍