### PR TITLE
refacto: publishers (proposal)

### DIFF
--- a/src/classes/PublisherAbstract.ts
+++ b/src/classes/PublisherAbstract.ts
@@ -7,13 +7,5 @@ export abstract class Publisher<T> {
 
 	constructor(protected connection: Connection) {}
 
-	public async publish(data: T) {
-		this.channel = await this.connection.createChannel();
-
-		await this.channel.assertQueue(this.queueName, { durable: true });
-
-		this.channel.sendToQueue(this.queueName, Buffer.from(JSON.stringify(data)));
-
-		console.log('Published expiration event');
-	}
+	public abstract publish(data: T): Promise<void>;
 }

--- a/src/classes/QueuePublisherAbstract.ts
+++ b/src/classes/QueuePublisherAbstract.ts
@@ -1,0 +1,13 @@
+import { Publisher } from './PublisherAbstract';
+
+export abstract class QueuePublisher<T> extends Publisher<T> {
+	public async publish(data: T) {
+		this.channel = await this.connection.createChannel();
+
+		await this.channel.assertQueue(this.queueName, { durable: true });
+
+		this.channel.sendToQueue(this.queueName, Buffer.from(JSON.stringify(data)));
+
+		console.log('Published expiration event');
+	}
+}


### PR DESCRIPTION
For the publishers, I'd rather thought of something like that.
The `Publisher` class is an abstract class with only [pure virtual functions](https://www.geeksforgeeks.org/pure-virtual-functions-and-abstract-classes/). And the derived classes must implements their own version of the publish method.

It makes more sense to me for this use case where we can have 4 differents kind of publish with rabbitMQ. I find it cleaner to have their implementations at the same level of inheritance.

What do you think ?